### PR TITLE
Added new ubuntu url's

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,8 +51,8 @@
   },
   "scripts": {
     "pre-install-cmd": [
-      "test -f /app/.heroku/mysql-client-core.deb || wget http://security.ubuntu.com/ubuntu/pool/main/m/mysql-5.7/mysql-client-core-5.7_5.7.20-0ubuntu0.16.04.1_amd64.deb -qO /app/.heroku/mysql-client-core.deb",
-      "test -f /app/.heroku/mysql-core.deb || wget http://security.ubuntu.com/ubuntu/pool/main/m/mysql-5.7/mysql-client-5.7_5.7.20-0ubuntu0.16.04.1_amd64.deb -qO /app/.heroku/mysql-client.deb",
+      "test -f /app/.heroku/mysql-client-core.deb || wget http://security.ubuntu.com/ubuntu/pool/main/m/mysql-5.7/mysql-client-core-5.7_5.7.21-0ubuntu0.16.04.1_amd64.deb -qO /app/.heroku/mysql-client-core.deb",
+      "test -f /app/.heroku/mysql-core.deb || wget http://security.ubuntu.com/ubuntu/pool/main/m/mysql-5.7/mysql-client-5.7_5.7.21-0ubuntu0.16.04.1_amd64.deb -qO /app/.heroku/mysql-client.deb",
       "dpkg -x /app/.heroku/mysql-client.deb /app/.heroku/mysql; dpkg -x /app/.heroku/mysql-client-core.deb /app/.heroku/mysql",
       "chmod +x /app/.heroku/mysql/usr/bin/* && mv /app/.heroku/mysql/usr/bin/* /app/.heroku/php/bin/"
     ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "wordpress-heroku-docker-project",
+  "version": "1.0.0",
+  "lockfileVersion": 1
+}


### PR DESCRIPTION
The original ubuntu security release url's were down so I've updated them. This fixes the initial composer install "pre-install-cmd" that runs.